### PR TITLE
allow blaze-markup-0.6

### DIFF
--- a/blaze-svg.cabal
+++ b/blaze-svg.cabal
@@ -46,7 +46,7 @@ Library
   Build-depends:
     base            >= 4  && < 5,
     mtl             >= 2  && < 3,
-    blaze-markup    >= 0.5 && < 0.6
+    blaze-markup    >= 0.5 && < 0.7
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
`blaze-svg` builds fine with the latest `blaze-markup`.
