### PR TITLE
Bump blaze-markup upper version bounds

### DIFF
--- a/blaze-svg.cabal
+++ b/blaze-svg.cabal
@@ -46,7 +46,7 @@ Library
   Build-depends:
     base            >= 4  && < 5,
     mtl             >= 2  && < 3,
-    blaze-markup    >= 0.5 && < 0.7
+    blaze-markup    >= 0.5 && < 0.8
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
Allow `blaze-svg` to build with the latest version of `blaze-markup` (0.7).