### PR TITLE
Adding support for elliptical curves

### DIFF
--- a/blaze-svg.cabal
+++ b/blaze-svg.cabal
@@ -1,5 +1,5 @@
 name:                blaze-svg
-version:             0.3.4.1
+version:             0.3.5.1
 synopsis:            SVG combinator library
 homepage:            https://github.com/deepakjois/blaze-svg
 license:             BSD3

--- a/blaze-svg.cabal
+++ b/blaze-svg.cabal
@@ -1,5 +1,5 @@
 name:                blaze-svg
-version:             0.3.5.1
+version:             0.3.4.1
 synopsis:            SVG combinator library
 homepage:            https://github.com/deepakjois/blaze-svg
 license:             BSD3

--- a/src/Text/Blaze/Svg.hs
+++ b/src/Text/Blaze/Svg.hs
@@ -15,6 +15,8 @@ module Text.Blaze.Svg
     , c, cr, s, sr
     -- ** The quadratic Bézier curve commands
     , q, qr, t, tr
+    -- ** Elliptical arc
+    , ar
     -- * SVG Transform combinators
     , translate, rotate, rotateAround, scale
     , skewX, skewY

--- a/src/Text/Blaze/Svg.hs
+++ b/src/Text/Blaze/Svg.hs
@@ -16,7 +16,7 @@ module Text.Blaze.Svg
     -- ** The quadratic Bézier curve commands
     , q, qr, t, tr
     -- ** Elliptical arc
-    , ar
+    , aa , ar
     -- * SVG Transform combinators
     , translate, rotate, rotateAround, scale
     , skewX, skewY

--- a/src/Text/Blaze/Svg/Internal.hs
+++ b/src/Text/Blaze/Svg/Internal.hs
@@ -2,6 +2,8 @@
 module Text.Blaze.Svg.Internal where
 
 import Control.Monad.State
+import Data.Monoid (mappend, mempty)
+
 import Text.Blaze
 
 -- | Type to represent an SVG document fragment.
@@ -185,7 +187,7 @@ tr x y = appendToPath
   ]
  
 -- | Elliptical Arc (absolute)
-a
+aAbs
   :: Show a
   => a -- ^ Radius in the x-direction
   -> a -- ^ Radius in the y-direction
@@ -195,7 +197,7 @@ a
   -> a -- ^ The x-coordinate of the end point
   -> a -- ^ The y-coordinate of the end point
   -> Path
-a rx ry xAxisRotation largeArcFlag sweepFlag x y = appendToPath
+aAbs rx ry xAxisRotation largeArcFlag sweepFlag x y = appendToPath
   [ "A "
   , show rx, ",", show ry, " "
   , show xAxisRotation, " "

--- a/src/Text/Blaze/Svg/Internal.hs
+++ b/src/Text/Blaze/Svg/Internal.hs
@@ -2,8 +2,6 @@
 module Text.Blaze.Svg.Internal where
 
 import Control.Monad.State
-import Data.Monoid (mappend, mempty)
-
 import Text.Blaze
 
 -- | Type to represent an SVG document fragment.
@@ -184,6 +182,44 @@ tr x y = appendToPath
   , " "
   , show x, ",", show y
   , " "
+  ]
+ 
+-- | Elliptical Arc (absolute)
+a
+  :: Show a
+  => a -- ^ Radius in the x-direction
+  -> a -- ^ Radius in the y-direction
+  -> Int -- ^ The rotation of the arc's x-axis compared to the normal x-axis
+  -> Int -- ^ Draw the smaller or bigger arc satisfying the start point
+  -> Int -- ^ To mirror or not
+  -> a -- ^ The x-coordinate of the end point
+  -> a -- ^ The y-coordinate of the end point
+  -> Path
+a rx ry xAxisRotation largeArcFlag sweepFlag x y = appendToPath
+  [ "A "
+  , show rx, ",", show ry, " "
+  , show xAxisRotation, " "
+  , show largeArcFlag, ",", show sweepFlag, " "
+  , show x, ",", show y, " "
+  ]
+
+-- | Elliptical Arc (relative)
+ar
+  :: Show a
+  => a -- ^ Radius in the x-direction
+  -> a -- ^ Radius in the y-direction
+  -> Int -- ^ The rotation of the arc's x-axis compared to the normal x-axis
+  -> Int -- ^ Draw the smaller or bigger arc satisfying the start point
+  -> Int -- ^ To mirror or not
+  -> a -- ^ The x-coordinate of the end point
+  -> a -- ^ The y-coordinate of the end point
+  -> Path
+ar rx ry xAxisRotation largeArcFlag sweepFlag x y = appendToPath
+  [ "a "
+  , show rx, ",", show ry, " "
+  , show xAxisRotation, " "
+  , show largeArcFlag, ",", show sweepFlag, " "
+  , show x, ",", show y, " "
   ]
 
 -- | Specifies a translation by @x@ and @y@

--- a/src/Text/Blaze/Svg/Internal.hs
+++ b/src/Text/Blaze/Svg/Internal.hs
@@ -186,18 +186,35 @@ tr x y = appendToPath
   , " "
   ]
  
--- | Elliptical Arc (absolute)
-aAbs
+-- | Elliptical Arc (absolute). This function is an alias for 'a' defined in
+-- this module. It is defined so that it can be exported instead of the a
+-- function due to naming conflicts with 'Text.Blaze.SVG11.a'.
+aa
   :: Show a
   => a -- ^ Radius in the x-direction
   -> a -- ^ Radius in the y-direction
-  -> Int -- ^ The rotation of the arc's x-axis compared to the normal x-axis
-  -> Int -- ^ Draw the smaller or bigger arc satisfying the start point
-  -> Int -- ^ To mirror or not
+  -> a -- ^ The rotation of the arc's x-axis compared to the normal x-axis
+  -> a -- ^ Draw the smaller or bigger arc satisfying the start point
+  -> a -- ^ To mirror or not
   -> a -- ^ The x-coordinate of the end point
   -> a -- ^ The y-coordinate of the end point
   -> Path
-aAbs rx ry xAxisRotation largeArcFlag sweepFlag x y = appendToPath
+aa = a
+
+-- | Elliptical Arc (absolute). This is the internal definition for absolute
+-- arcs. It is not exported but instead exported as 'aa' due to naming
+-- conflicts with 'Text.Blaze.SVG11.a'.
+a
+  :: Show a
+  => a -- ^ Radius in the x-direction
+  -> a -- ^ Radius in the y-direction
+  -> a -- ^ The rotation of the arc's x-axis compared to the normal x-axis
+  -> a -- ^ Draw the smaller or bigger arc satisfying the start point
+  -> a -- ^ To mirror or not
+  -> a -- ^ The x-coordinate of the end point
+  -> a -- ^ The y-coordinate of the end point
+  -> Path
+a rx ry xAxisRotation largeArcFlag sweepFlag x y = appendToPath
   [ "A "
   , show rx, ",", show ry, " "
   , show xAxisRotation, " "
@@ -210,9 +227,9 @@ ar
   :: Show a
   => a -- ^ Radius in the x-direction
   -> a -- ^ Radius in the y-direction
-  -> Int -- ^ The rotation of the arc's x-axis compared to the normal x-axis
-  -> Int -- ^ Draw the smaller or bigger arc satisfying the start point
-  -> Int -- ^ To mirror or not
+  -> a -- ^ The rotation of the arc's x-axis compared to the normal x-axis
+  -> a -- ^ Draw the smaller or bigger arc satisfying the start point
+  -> a -- ^ To mirror or not
   -> a -- ^ The x-coordinate of the end point
   -> a -- ^ The y-coordinate of the end point
   -> Path
@@ -275,9 +292,9 @@ skewY skewAngle = toValue . join $
 
 -- | Specifies a transform in the form of a transformation matrix
 matrix :: Show a => a -> a -> a -> a -> a -> a -> AttributeValue
-matrix a b c_ d e f =  toValue . join $
+matrix a_ b c_ d e f =  toValue . join $
   [  "matrix("
-  ,  show a, ","
+  ,  show a_, ","
   ,  show b, ","
   ,  show c_, ","
   ,  show d, ","


### PR DESCRIPTION
You might notice I have not exported Text.Blaze.Svg.Internal.a from Text.Blaze.Svg. This is because it conflicts with Text,Blaze,Svg11.a. Solving this problem is any manner would break from some at least one of the defacto standards created by the package author so I didn't want to do that without some guidance. I'm happy to do whatever and send a second pull request or perhaps amend this one once a decision has been made. 