### PR TITLE
Add toSvg function

### DIFF
--- a/src/Text/Blaze/Svg.hs
+++ b/src/Text/Blaze/Svg.hs
@@ -3,6 +3,7 @@ module Text.Blaze.Svg
     (
       Svg
     , Path
+    , toSvg
     -- * SVG Path combinators
     , mkPath
     -- ** \"moveto\" commands

--- a/src/Text/Blaze/Svg/Internal.hs
+++ b/src/Text/Blaze/Svg/Internal.hs
@@ -8,6 +8,9 @@ import           Text.Blaze
 -- | Type to represent an SVG document fragment.
 type Svg = Markup
 
+toSvg :: ToMarkup a => a -> Svg
+toSvg = toMarkup
+
 -- | Type to accumulate an SVG path.
 type Path = State AttributeValue ()
 


### PR DESCRIPTION
This PR adds `toSvg` function to `Text.Blaze.Svg.Internal` as in
`Text.Blaze.Html`.

Some tags like <text/> can contain string as its content.
But, the current version of blaze-svg lacks this feature because of automatic
generation of tag-related functions.

When this PR is accepted, `src/Util/GenerateSvgCombinators.hs` must be changed so that some tags will be parents instead of leaves.